### PR TITLE
Silence specific warnings we that we are not fixing

### DIFF
--- a/wiringPi/Makefile
+++ b/wiringPi/Makefile
@@ -39,7 +39,8 @@ DEBUG	= -O2
 CC	= gcc
 INCLUDE	= -I.
 DEFS	= -D_GNU_SOURCE
-CFLAGS	= $(DEBUG) $(DEFS) -Wformat=2 -Wall -Wextra -Winline $(INCLUDE) -pipe -fPIC
+NWFLAGS = -Wno-unused-function -Wno-unused-result -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast
+CFLAGS	= $(DEBUG) $(DEFS) -Wformat=2 -Wall -Wextra -Winline $(NWFLAGS) $(INCLUDE) -pipe -fPIC
 
 LIBS    = -lm -lpthread -lrt -lcrypt
 


### PR DESCRIPTION
Silence specific warnings (that we are not fixing) with flags in makefile